### PR TITLE
feat: budget alerts and hard kill switches

### DIFF
--- a/README.md
+++ b/README.md
@@ -131,6 +131,41 @@ response = client.chat.completions.create(
 )
 ```
 
+### Budget Controls
+
+Set spending limits with soft alerts or hard kill switches that abort requests before they reach the LLM API.
+
+```bash
+# Soft alert — warns in server logs, still forwards the request
+llm-cost-monitor budget set --limit 5.00 --period daily
+
+# Hard kill switch — returns HTTP 429 once $1/hour is exceeded
+llm-cost-monitor budget set --name ci --limit 1.00 --period hourly --hard-kill
+
+# View all budgets with current spend
+llm-cost-monitor budget list
+```
+
+Budgets are also manageable via the REST API:
+```bash
+# Create/update a budget
+curl -X POST http://localhost:8877/api/budgets \
+  -H 'Content-Type: application/json' \
+  -d '{"name": "default", "limit_usd": 5.0, "period": "daily", "hard_kill": false}'
+
+# Check status (useful for dashboard polling)
+curl http://localhost:8877/api/budgets/status
+```
+
+When a hard kill budget is exceeded, callers receive a structured `429`:
+```json
+{
+  "error": "budget_exceeded",
+  "message": "Budget 'default' exceeded: $5.0012 spent of $5.0000 daily limit.",
+  "budget": { "name": "default", "limit": 5.0, "spent": 5.0012, "period": "daily" }
+}
+```
+
 ### CLI Summary
 ```bash
 llm-cost-monitor summary --hours 24
@@ -197,7 +232,7 @@ If a model isn't in the pricing table, the request is still proxied and logged (
 
 ## Roadmap
 
-- [ ] Budget alerts and hard kill switches (abort request if budget exceeded)
+- [x] Budget alerts and hard kill switches (abort request if budget exceeded)
 - [ ] Streaming response support with token counting
 - [ ] Export to CSV/JSON
 - [ ] Prometheus metrics endpoint

--- a/llm_cost_monitor/__main__.py
+++ b/llm_cost_monitor/__main__.py
@@ -20,6 +20,21 @@ def main():
     summary_parser = subparsers.add_parser("summary", help="Show cost summary")
     summary_parser.add_argument("--hours", type=int, default=24, help="Hours to look back (default: 24)")
 
+    # Budget commands
+    budget_parser = subparsers.add_parser("budget", help="Manage spending budgets")
+    budget_sub = budget_parser.add_subparsers(dest="budget_command")
+
+    budget_set = budget_sub.add_parser("set", help="Create or update a budget")
+    budget_set.add_argument("--name", default="default", help="Budget name (default: 'default')")
+    budget_set.add_argument("--limit", type=float, required=True, help="Spending limit in USD")
+    budget_set.add_argument("--period", choices=["hourly", "daily", "weekly", "monthly"], default="daily")
+    budget_set.add_argument("--hard-kill", action="store_true", help="Abort requests when budget is exceeded")
+
+    budget_sub.add_parser("list", help="List all budgets with current spend")
+
+    budget_del = budget_sub.add_parser("delete", help="Delete a budget")
+    budget_del.add_argument("name", help="Budget name to delete")
+
     # Reset command
     subparsers.add_parser("reset", help="Clear all logged data")
 
@@ -70,6 +85,45 @@ def main():
             print(f"\n  By Model:")
             for m in models:
                 print(f"    {m['model']:40s} ${m['total_cost']:.4f}  ({m['requests']} reqs)")
+
+    elif args.command == "budget":
+        from .db import init_db, set_budget, list_budgets, delete_budget
+
+        init_db()
+
+        if args.budget_command == "set":
+            result = set_budget(args.name, args.limit, args.period, args.hard_kill)
+            kill_label = " [HARD KILL]" if result["hard_kill"] else ""
+            print(f"\nBudget '{result['name']}' set{kill_label}")
+            print(f"  Limit:   ${result['limit']:.4f} / {result['period']}")
+            print(f"  Spent:   ${result['spent']:.4f}")
+            print(f"  Status:  {'EXCEEDED' if result['exceeded'] else 'OK'}")
+
+        elif args.budget_command == "list":
+            budgets = list_budgets()
+            if not budgets:
+                print("No budgets configured. Use: llm-cost-monitor budget set --limit <USD>")
+            else:
+                print(f"\n{'NAME':<20} {'PERIOD':<10} {'LIMIT':>10} {'SPENT':>10} {'REMAINING':>12} {'STATUS'}")
+                print("-" * 72)
+                for b in budgets:
+                    status = "EXCEEDED" if b["exceeded"] else "OK"
+                    if b["hard_kill"] and b["exceeded"]:
+                        status = "KILLED"
+                    print(
+                        f"{b['name']:<20} {b['period']:<10} "
+                        f"${b['limit']:>9.4f} ${b['spent']:>9.4f} "
+                        f"${b['remaining']:>11.4f} {status}"
+                    )
+
+        elif args.budget_command == "delete":
+            from .db import delete_budget
+            if delete_budget(args.name):
+                print(f"Budget '{args.name}' deleted.")
+            else:
+                print(f"Budget '{args.name}' not found.")
+        else:
+            budget_parser.print_help()
 
     elif args.command == "reset":
         import os

--- a/llm_cost_monitor/db.py
+++ b/llm_cost_monitor/db.py
@@ -55,9 +55,16 @@ def init_db():
             name TEXT UNIQUE NOT NULL,
             limit_usd REAL NOT NULL,
             period TEXT NOT NULL DEFAULT 'daily',
-            active INTEGER DEFAULT 1
+            active INTEGER DEFAULT 1,
+            hard_kill INTEGER DEFAULT 0
         );
     """)
+    # Migrate: add hard_kill column if upgrading from an older schema
+    try:
+        conn.execute("ALTER TABLE budgets ADD COLUMN hard_kill INTEGER DEFAULT 0")
+        conn.commit()
+    except Exception:
+        pass  # Column already exists
     conn.commit()
     conn.close()
 
@@ -205,17 +212,8 @@ def get_cost_by_tag(hours: int = 24):
     return [dict(r) for r in rows]
 
 
-def check_budget(name: str) -> dict | None:
-    """Check if a budget limit has been exceeded."""
-    conn = get_connection()
-    budget = conn.execute(
-        "SELECT * FROM budgets WHERE name = ? AND active = 1", (name,)
-    ).fetchone()
-
-    if not budget:
-        conn.close()
-        return None
-
+def _budget_status(budget: sqlite3.Row, conn: sqlite3.Connection) -> dict:
+    """Compute current spend against a budget row and return a status dict."""
     period_hours = {"hourly": 1, "daily": 24, "weekly": 168, "monthly": 720}
     hours = period_hours.get(budget["period"], 24)
     since = time.time() - (hours * 3600)
@@ -225,12 +223,80 @@ def check_budget(name: str) -> dict | None:
         (since,),
     ).fetchone()
 
-    conn.close()
     return {
         "name": budget["name"],
         "limit": budget["limit_usd"],
-        "spent": spent["spent"],
-        "remaining": budget["limit_usd"] - spent["spent"],
+        "spent": round(spent["spent"], 6),
+        "remaining": round(budget["limit_usd"] - spent["spent"], 6),
         "exceeded": spent["spent"] >= budget["limit_usd"],
         "period": budget["period"],
+        "hard_kill": bool(budget["hard_kill"]),
+        "active": bool(budget["active"]),
     }
+
+
+def check_budget(name: str) -> dict | None:
+    """Check if a named budget limit has been exceeded. Returns None if not found."""
+    conn = get_connection()
+    budget = conn.execute(
+        "SELECT * FROM budgets WHERE name = ? AND active = 1", (name,)
+    ).fetchone()
+
+    if not budget:
+        conn.close()
+        return None
+
+    result = _budget_status(budget, conn)
+    conn.close()
+    return result
+
+
+def check_all_budgets() -> list[dict]:
+    """Return status for all active budgets."""
+    conn = get_connection()
+    budgets = conn.execute("SELECT * FROM budgets WHERE active = 1").fetchall()
+    result = [_budget_status(b, conn) for b in budgets]
+    conn.close()
+    return result
+
+
+def set_budget(name: str, limit_usd: float, period: str = "daily", hard_kill: bool = False) -> dict:
+    """Create or update a named budget. Returns the new status."""
+    valid_periods = {"hourly", "daily", "weekly", "monthly"}
+    if period not in valid_periods:
+        raise ValueError(f"period must be one of: {', '.join(sorted(valid_periods))}")
+
+    conn = get_connection()
+    conn.execute(
+        """INSERT INTO budgets (name, limit_usd, period, hard_kill, active)
+           VALUES (?, ?, ?, ?, 1)
+           ON CONFLICT(name) DO UPDATE SET
+               limit_usd = excluded.limit_usd,
+               period = excluded.period,
+               hard_kill = excluded.hard_kill,
+               active = 1""",
+        (name, limit_usd, period, int(hard_kill)),
+    )
+    conn.commit()
+    budget = conn.execute("SELECT * FROM budgets WHERE name = ?", (name,)).fetchone()
+    result = _budget_status(budget, conn)
+    conn.close()
+    return result
+
+
+def delete_budget(name: str) -> bool:
+    """Delete a budget by name. Returns True if it existed."""
+    conn = get_connection()
+    cursor = conn.execute("DELETE FROM budgets WHERE name = ?", (name,))
+    conn.commit()
+    conn.close()
+    return cursor.rowcount > 0
+
+
+def list_budgets() -> list[dict]:
+    """Return all budgets (active and inactive) with current spend status."""
+    conn = get_connection()
+    budgets = conn.execute("SELECT * FROM budgets ORDER BY name").fetchall()
+    result = [_budget_status(b, conn) for b in budgets]
+    conn.close()
+    return result

--- a/llm_cost_monitor/server.py
+++ b/llm_cost_monitor/server.py
@@ -16,7 +16,11 @@ from fastapi import FastAPI, Request, Response
 from fastapi.responses import HTMLResponse, JSONResponse
 from fastapi.middleware.cors import CORSMiddleware
 
-from .db import init_db, log_request, get_summary, get_cost_by_model, get_cost_over_time, get_recent_requests, get_cost_by_provider, get_cost_by_tag
+from .db import (
+    init_db, log_request, get_summary, get_cost_by_model, get_cost_over_time,
+    get_recent_requests, get_cost_by_provider, get_cost_by_tag,
+    check_all_budgets, set_budget, delete_budget, list_budgets,
+)
 from .pricing import calculate_cost
 from .providers import detect_provider
 
@@ -94,6 +98,59 @@ async def api_by_tag(hours: int = 24):
 
 
 # ──────────────────────────────────────────────
+# Budget management endpoints
+# ──────────────────────────────────────────────
+
+@app.get("/api/budgets")
+async def api_list_budgets():
+    """List all budgets with current spend status."""
+    return JSONResponse(list_budgets())
+
+
+@app.post("/api/budgets")
+async def api_set_budget(request: Request):
+    """Create or update a budget.
+
+    Body: {"name": str, "limit_usd": float, "period": "hourly|daily|weekly|monthly", "hard_kill": bool}
+    """
+    try:
+        body = await request.json()
+        name = body.get("name", "default")
+        limit_usd = float(body["limit_usd"])
+        period = body.get("period", "daily")
+        hard_kill = bool(body.get("hard_kill", False))
+    except (KeyError, ValueError, TypeError) as e:
+        return JSONResponse({"error": f"Invalid request: {e}"}, status_code=400)
+
+    try:
+        result = set_budget(name, limit_usd, period, hard_kill)
+    except ValueError as e:
+        return JSONResponse({"error": str(e)}, status_code=400)
+
+    return JSONResponse(result, status_code=201)
+
+
+@app.delete("/api/budgets/{name}")
+async def api_delete_budget(name: str):
+    """Delete a budget by name."""
+    deleted = delete_budget(name)
+    if not deleted:
+        return JSONResponse({"error": f"Budget '{name}' not found"}, status_code=404)
+    return JSONResponse({"deleted": name})
+
+
+@app.get("/api/budgets/status")
+async def api_budget_status():
+    """Check all active budgets and return any that are exceeded."""
+    all_budgets = check_all_budgets()
+    return JSONResponse({
+        "budgets": all_budgets,
+        "any_exceeded": any(b["exceeded"] for b in all_budgets),
+        "hard_kill_triggered": any(b["exceeded"] and b["hard_kill"] for b in all_budgets),
+    })
+
+
+# ──────────────────────────────────────────────
 # Proxy endpoints - one per provider
 # ──────────────────────────────────────────────
 
@@ -128,6 +185,31 @@ async def proxy_groq(request: Request, path: str):
 async def _proxy_request(request: Request, target_url: str, provider_hint: str):
     """Forward request to target, log cost on response."""
     start = time.time()
+
+    # ── Budget check ──────────────────────────────────────────────────────────
+    # Check all active budgets before forwarding. Hard-kill budgets abort the
+    # request with a 429; soft budgets log a warning but still forward.
+    for budget in check_all_budgets():
+        if budget["exceeded"]:
+            msg = (
+                f"Budget '{budget['name']}' exceeded: "
+                f"${budget['spent']:.4f} spent of ${budget['limit']:.4f} "
+                f"{budget['period']} limit."
+            )
+            if budget["hard_kill"]:
+                logger.warning(f"Hard kill triggered. {msg}")
+                return JSONResponse(
+                    {
+                        "error": "budget_exceeded",
+                        "message": msg,
+                        "budget": budget,
+                    },
+                    status_code=429,
+                    headers={"Retry-After": "3600"},
+                )
+            else:
+                logger.warning(f"Soft budget alert. {msg}")
+    # ─────────────────────────────────────────────────────────────────────────
 
     # Extract request data
     body_bytes = await request.body()


### PR DESCRIPTION
## Summary

Closes #2

Adds configurable spending budgets with two enforcement modes: soft alerts (warn but forward) and hard kill switches (abort with HTTP 429 before the request reaches the LLM API).

### Changes

**`llm_cost_monitor/db.py`**
- Added `hard_kill` column to `budgets` table with automatic schema migration for existing databases
- New functions: `set_budget()`, `delete_budget()`, `list_budgets()`, `check_all_budgets()`
- `check_budget()` now includes `hard_kill` and `active` in returned data

**`llm_cost_monitor/server.py`**
- Budget check runs at the top of `_proxy_request` before any I/O — hard-kill budgets abort with `429 Too Many Requests` + `Retry-After: 3600`
- New REST endpoints:
  - `GET /api/budgets` — list all budgets with current spend
  - `POST /api/budgets` — create or update a budget
  - `DELETE /api/budgets/{name}` — delete a budget
  - `GET /api/budgets/status` — poll for exceeded budgets (for dashboard integration)

**`llm_cost_monitor/__main__.py`**
- New `budget` subcommand with `set`, `list`, and `delete` sub-commands

### Usage

```bash
# Set a soft daily budget (warns in logs, still forwards)
llm-cost-monitor budget set --limit 5.00 --period daily

# Set a hard kill switch (aborts requests once $1/hour is exceeded)
llm-cost-monitor budget set --name ci --limit 1.00 --period hourly --hard-kill

# View all budgets
llm-cost-monitor budget list

# API
curl -X POST http://localhost:8877/api/budgets \
  -H 'Content-Type: application/json' \
  -d '{"name": "default", "limit_usd": 5.0, "period": "daily", "hard_kill": false}'
```

### Hard kill response (HTTP 429)
```json
{
  "error": "budget_exceeded",
  "message": "Budget 'default' exceeded: $5.0012 spent of $5.0000 daily limit.",
  "budget": { "name": "default", "limit": 5.0, "spent": 5.0012, ... }
}
```

## Test plan

- [ ] `llm-cost-monitor budget set --limit 0.001 --hard-kill` then make any LLM call — confirm 429 returned
- [ ] Remove `--hard-kill` — confirm request still forwards but warning appears in server logs
- [ ] `llm-cost-monitor budget list` — confirm spend shown correctly
- [ ] `GET /api/budgets/status` — confirm `hard_kill_triggered: true` when exceeded
- [ ] Upgrade test: run with existing DB (no `hard_kill` column) — confirm migration works without error