### PR TITLE
feat: export cost data to CSV and JSON

### DIFF
--- a/README.md
+++ b/README.md
@@ -181,6 +181,31 @@ When a hard kill budget is exceeded, callers receive a structured `429`:
 }
 ```
 
+### Export to CSV / JSON
+
+Export your cost data for spreadsheets, BI tools, or custom scripts.
+
+```bash
+# Export last 24h as CSV (default)
+llm-cost-monitor export --output costs.csv
+
+# Export as JSON
+llm-cost-monitor export --format json --output costs.json
+
+# Export all historical data
+llm-cost-monitor export --all --output full-history.csv
+
+# Filter by provider, model, or tag
+llm-cost-monitor export --provider openai --hours 168 --output openai-week.csv
+llm-cost-monitor export --model gpt-4o --tag agent-run --format json
+```
+
+The dashboard also has a one-click download:
+```
+GET http://localhost:8877/api/export?format=csv&hours=24
+GET http://localhost:8877/api/export?format=json&all=true&provider=anthropic
+```
+
 ### CLI Summary
 ```bash
 llm-cost-monitor summary --hours 24
@@ -249,7 +274,7 @@ If a model isn't in the pricing table, the request is still proxied and logged (
 
 - [x] Budget alerts and hard kill switches (abort request if budget exceeded)
 - [x] Streaming response support with token counting
-- [ ] Export to CSV/JSON
+- [x] Export to CSV/JSON
 - [ ] Prometheus metrics endpoint
 - [ ] Slack/Discord alerts when spend exceeds threshold
 - [ ] Team mode with per-user tracking

--- a/llm_cost_monitor/__main__.py
+++ b/llm_cost_monitor/__main__.py
@@ -20,6 +20,16 @@ def main():
     summary_parser = subparsers.add_parser("summary", help="Show cost summary")
     summary_parser.add_argument("--hours", type=int, default=24, help="Hours to look back (default: 24)")
 
+    # Export command
+    export_parser = subparsers.add_parser("export", help="Export cost data to CSV or JSON")
+    export_parser.add_argument("--format", choices=["csv", "json"], default="csv", help="Output format (default: csv)")
+    export_parser.add_argument("--output", "-o", default=None, help="Output file path (default: stdout)")
+    export_parser.add_argument("--hours", type=int, default=24, help="Hours to look back (default: 24)")
+    export_parser.add_argument("--all", action="store_true", help="Export all data (ignores --hours)")
+    export_parser.add_argument("--model", default=None, help="Filter by model name")
+    export_parser.add_argument("--provider", default=None, help="Filter by provider")
+    export_parser.add_argument("--tag", default=None, help="Filter by tag")
+
     # Budget commands
     budget_parser = subparsers.add_parser("budget", help="Manage spending budgets")
     budget_sub = budget_parser.add_subparsers(dest="budget_command")
@@ -85,6 +95,71 @@ def main():
             print(f"\n  By Model:")
             for m in models:
                 print(f"    {m['model']:40s} ${m['total_cost']:.4f}  ({m['requests']} reqs)")
+
+    elif args.command == "export":
+        import csv
+        import io
+        import sys
+        from datetime import datetime, timezone
+        from .db import init_db, get_export_data, get_summary
+
+        init_db()
+
+        rows = get_export_data(
+            hours=None if args.all else args.hours,
+            model=args.model,
+            provider=args.provider,
+            tag=args.tag,
+        )
+
+        if args.format == "csv":
+            output = io.StringIO()
+            fieldnames = [
+                "timestamp", "model", "provider",
+                "input_tokens", "output_tokens", "total_tokens",
+                "input_cost", "output_cost", "total_cost",
+                "latency_ms", "status_code", "tag", "endpoint",
+            ]
+            writer = csv.DictWriter(output, fieldnames=fieldnames, extrasaction="ignore")
+            writer.writeheader()
+            for row in rows:
+                row["timestamp"] = datetime.fromtimestamp(
+                    row["timestamp"], tz=timezone.utc
+                ).strftime("%Y-%m-%dT%H:%M:%SZ")
+                writer.writerow(row)
+            content = output.getvalue()
+        else:
+            summary = {
+                "total_requests": len(rows),
+                "total_cost": round(sum(r["total_cost"] for r in rows), 6),
+                "total_input_tokens": sum(r["input_tokens"] for r in rows),
+                "total_output_tokens": sum(r["output_tokens"] for r in rows),
+            }
+            for row in rows:
+                row["timestamp"] = datetime.fromtimestamp(
+                    row["timestamp"], tz=timezone.utc
+                ).strftime("%Y-%m-%dT%H:%M:%SZ")
+            payload = {
+                "exported_at": datetime.now(timezone.utc).isoformat(),
+                "filters": {
+                    "hours": None if args.all else args.hours,
+                    "all": args.all,
+                    "model": args.model,
+                    "provider": args.provider,
+                    "tag": args.tag,
+                },
+                "summary": summary,
+                "requests": rows,
+            }
+            import json as _json
+            content = _json.dumps(payload, indent=2)
+
+        if args.output:
+            with open(args.output, "w") as f:
+                f.write(content)
+            print(f"Exported {len(rows)} record(s) to {args.output}")
+        else:
+            sys.stdout.write(content)
 
     elif args.command == "budget":
         from .db import init_db, set_budget, list_budgets, delete_budget

--- a/llm_cost_monitor/db.py
+++ b/llm_cost_monitor/db.py
@@ -212,6 +212,56 @@ def get_cost_by_tag(hours: int = 24):
     return [dict(r) for r in rows]
 
 
+def get_export_data(
+    hours: int | None = 24,
+    since_ts: float | None = None,
+    until_ts: float | None = None,
+    model: str | None = None,
+    provider: str | None = None,
+    tag: str | None = None,
+) -> list[dict]:
+    """
+    Fetch requests for export with optional filters.
+
+    Priority: explicit since_ts/until_ts > hours > all data (hours=None).
+    """
+    conn = get_connection()
+
+    conditions = []
+    params = []
+
+    if since_ts is not None:
+        conditions.append("timestamp >= ?")
+        params.append(since_ts)
+    elif hours is not None:
+        conditions.append("timestamp >= ?")
+        params.append(time.time() - hours * 3600)
+
+    if until_ts is not None:
+        conditions.append("timestamp <= ?")
+        params.append(until_ts)
+
+    if model:
+        conditions.append("model = ?")
+        params.append(model)
+
+    if provider:
+        conditions.append("provider = ?")
+        params.append(provider)
+
+    if tag:
+        conditions.append("tag = ?")
+        params.append(tag)
+
+    where = f"WHERE {' AND '.join(conditions)}" if conditions else ""
+    rows = conn.execute(
+        f"SELECT * FROM requests {where} ORDER BY timestamp ASC",
+        params,
+    ).fetchall()
+    conn.close()
+    return [dict(r) for r in rows]
+
+
 def _budget_status(budget: sqlite3.Row, conn: sqlite3.Connection) -> dict:
     """Compute current spend against a budget row and return a status dict."""
     period_hours = {"hourly": 1, "daily": 24, "weekly": 168, "monthly": 720}

--- a/llm_cost_monitor/server.py
+++ b/llm_cost_monitor/server.py
@@ -5,21 +5,25 @@ A transparent proxy that sits between your app and any LLM API,
 tracking costs and serving a real-time dashboard.
 """
 
+import csv
+import io
 import time
 import json
 import os
 import logging
+from datetime import datetime, timezone
 from pathlib import Path
 
 import httpx
 from fastapi import FastAPI, Request, Response
-from fastapi.responses import HTMLResponse, JSONResponse
+from fastapi.responses import HTMLResponse, JSONResponse, StreamingResponse
 from fastapi.middleware.cors import CORSMiddleware
 
 from .db import (
     init_db, log_request, get_summary, get_cost_by_model, get_cost_over_time,
     get_recent_requests, get_cost_by_provider, get_cost_by_tag,
     check_all_budgets, set_budget, delete_budget, list_budgets,
+    get_export_data,
 )
 from .pricing import calculate_cost
 from .providers import detect_provider
@@ -96,6 +100,94 @@ async def api_recent(limit: int = 50):
 @app.get("/api/by-tag")
 async def api_by_tag(hours: int = 24):
     return JSONResponse(get_cost_by_tag(hours))
+
+
+# ──────────────────────────────────────────────
+# Export endpoint
+# ──────────────────────────────────────────────
+
+@app.get("/api/export")
+async def api_export(
+    format: str = "json",
+    hours: int | None = 24,
+    all: bool = False,
+    model: str | None = None,
+    provider: str | None = None,
+    tag: str | None = None,
+):
+    """
+    Export cost data as CSV or JSON.
+
+    Query params:
+      format   — csv | json (default: json)
+      hours    — look-back window (default: 24); ignored when all=true
+      all      — export entire history (overrides hours)
+      model    — filter by model name
+      provider — filter by provider
+      tag      — filter by tag
+    """
+    rows = get_export_data(
+        hours=None if all else hours,
+        model=model,
+        provider=provider,
+        tag=tag,
+    )
+
+    now_iso = datetime.now(timezone.utc).isoformat()
+
+    if format.lower() == "csv":
+        output = io.StringIO()
+        fieldnames = [
+            "timestamp", "model", "provider",
+            "input_tokens", "output_tokens", "total_tokens",
+            "input_cost", "output_cost", "total_cost",
+            "latency_ms", "status_code", "tag", "endpoint",
+        ]
+        writer = csv.DictWriter(output, fieldnames=fieldnames, extrasaction="ignore")
+        writer.writeheader()
+        for row in rows:
+            row["timestamp"] = datetime.fromtimestamp(
+                row["timestamp"], tz=timezone.utc
+            ).strftime("%Y-%m-%dT%H:%M:%SZ")
+            writer.writerow(row)
+
+        filename = f"llm-costs-{datetime.now(timezone.utc).strftime('%Y%m%d-%H%M%S')}.csv"
+        return Response(
+            content=output.getvalue(),
+            media_type="text/csv",
+            headers={"Content-Disposition": f'attachment; filename="{filename}"'},
+        )
+
+    # JSON
+    summary = {
+        "total_requests": len(rows),
+        "total_cost": round(sum(r["total_cost"] for r in rows), 6),
+        "total_input_tokens": sum(r["input_tokens"] for r in rows),
+        "total_output_tokens": sum(r["output_tokens"] for r in rows),
+    }
+    for row in rows:
+        row["timestamp"] = datetime.fromtimestamp(
+            row["timestamp"], tz=timezone.utc
+        ).strftime("%Y-%m-%dT%H:%M:%SZ")
+
+    payload = {
+        "exported_at": now_iso,
+        "filters": {
+            "hours": None if all else hours,
+            "all": all,
+            "model": model,
+            "provider": provider,
+            "tag": tag,
+        },
+        "summary": summary,
+        "requests": rows,
+    }
+    filename = f"llm-costs-{datetime.now(timezone.utc).strftime('%Y%m%d-%H%M%S')}.json"
+    return Response(
+        content=json.dumps(payload, indent=2),
+        media_type="application/json",
+        headers={"Content-Disposition": f'attachment; filename="{filename}"'},
+    )
 
 
 # ──────────────────────────────────────────────


### PR DESCRIPTION
## Summary

Closes #1

Implements CSV and JSON export via CLI and REST API, with filtering by time range, model, provider, and tag.

### Changes

**`llm_cost_monitor/db.py`**
- `get_export_data()` — flexible query supporting `hours`, `since_ts`/`until_ts`, `model`, `provider`, `tag` filters; results ordered by `timestamp ASC`

**`llm_cost_monitor/server.py`**
- `GET /api/export` — downloads directly from the dashboard or via curl
  - `format=csv|json` (default: json)
  - `hours=N` — look-back window (default: 24)
  - `all=true` — full history, ignores `hours`
  - `model`, `provider`, `tag` — optional filters
  - Sets `Content-Disposition: attachment` with a timestamped filename

**`llm_cost_monitor/__main__.py`**
- `llm-cost-monitor export` subcommand with `--format`, `--output`, `--hours`, `--all`, `--model`, `--provider`, `--tag`
- Writes to file with confirmation, or streams to stdout when `--output` is omitted

**`README.md`**
- New "Export to CSV / JSON" section under Features
- Roadmap item marked `[x]`

### Usage

```bash
# CSV to file
llm-cost-monitor export --output costs.csv

# JSON, full history
llm-cost-monitor export --format json --all --output full.json

# Filtered
llm-cost-monitor export --provider openai --hours 168 --output openai-week.csv

# Via API (browser download or curl)
curl "http://localhost:8877/api/export?format=csv&hours=24" -o costs.csv
curl "http://localhost:8877/api/export?format=json&all=true&provider=anthropic" -o anthropic.json
```

### JSON output shape
```json
{
  "exported_at": "2026-04-10T12:00:00+00:00",
  "filters": { "hours": 24, "all": false, "model": null, "provider": null, "tag": null },
  "summary": { "total_requests": 42, "total_cost": 0.38, "total_input_tokens": 180000, "total_output_tokens": 24000 },
  "requests": [...]
}
```

## Test plan

- [ ] `llm-cost-monitor export --output out.csv` — verify CSV has header row and correct columns
- [ ] `llm-cost-monitor export --format json --all` — verify JSON wraps requests with summary
- [ ] `--model gpt-4o` / `--provider anthropic` / `--tag foo` — verify filters reduce rows correctly
- [ ] `curl "localhost:8877/api/export?format=csv"` — verify file download with correct filename
- [ ] `llm-cost-monitor export` (no `--output`) — verify output goes to stdout

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added export functionality to download cost and request records in CSV or JSON formats
  * CLI command and REST API endpoint available for flexible data exports
  * Filter by time range (default: last 24 hours), model, provider, or tag
  * Option to export all historical data

<!-- end of auto-generated comment: release notes by coderabbit.ai -->